### PR TITLE
Update transaction_record.py

### DIFF
--- a/hddcoin/wallet/transaction_record.py
+++ b/hddcoin/wallet/transaction_record.py
@@ -58,4 +58,4 @@ class TransactionRecord(Streamable):
                     return uint32(block_index)
                 if farmer_parent == self.additions[0].parent_coin_info:
                     return uint32(block_index)
-        return None
+        return uint32(block_index)


### PR DESCRIPTION
This is the wallet fix that almost every other fork is using and prevents the pop-up error that lots of GUI users get when a block is found.